### PR TITLE
recalculate p and Q for He-3,4 daughters

### DIFF
--- a/src/SimpleFinder.cpp
+++ b/src/SimpleFinder.cpp
@@ -336,9 +336,28 @@ void SimpleFinder::ReconstructDecay(const Decay& decay) {
     std::array<KFParticle, 3> track;
 
     track.at(0) = GetTrack(index_1);
+    if(std::abs(decay.GetDaughters().at(0).GetPdgHypo()) == 1000020030 ||
+       std::abs(decay.GetDaughters().at(0).GetPdgHypo()) == 1000020040) {
+      int charge = (int)track.at(0).Q();
+      charge *= 2;
+      track.at(0).Q() = charge;
+      track.at(0).Px() *= std::abs(charge);
+      track.at(0).Py() *= std::abs(charge);
+      track.at(0).Pz() *= std::abs(charge);
+    }
 
     for (auto index_2 : indexes.at(1)) {
       track.at(1) = GetTrack(index_2);
+      if(std::abs(decay.GetDaughters().at(1).GetPdgHypo()) == 1000020030 ||
+         std::abs(decay.GetDaughters().at(1).GetPdgHypo()) == 1000020040) {
+        int charge = (int)track.at(1).Q();
+        charge *= 2;
+        track.at(1).Q() = charge;
+        track.at(1).Px() *= std::abs(charge);
+        track.at(1).Py() *= std::abs(charge);
+        track.at(1).Pz() *= std::abs(charge);
+      }
+
       if (!IsGoodPair(track.at(0), track.at(1), decay)) continue;
 
       KFParticleSIMD kf_mother = ConstructMother({track.at(0), track.at(1)}, pdgs);
@@ -363,6 +382,15 @@ void SimpleFinder::ReconstructDecay(const Decay& decay) {
         for (auto index_3 : indexes.at(2)) {
 
           track.at(2) = GetTrack(index_3);
+          if(std::abs(decay.GetDaughters().at(2).GetPdgHypo()) == 1000020030 ||
+             std::abs(decay.GetDaughters().at(2).GetPdgHypo()) == 1000020040) {
+            int charge = (int)track.at(2).Q();
+            charge *= 2;
+            track.at(2).Q() = charge;
+            track.at(2).Px() *= std::abs(charge);
+            track.at(2).Py() *= std::abs(charge);
+            track.at(2).Pz() *= std::abs(charge);
+          }
 
           if (!IsGoodThree(track.at(0), track.at(1), track.at(2), decay)) continue;
 

--- a/src/SimpleFinder.cpp
+++ b/src/SimpleFinder.cpp
@@ -336,9 +336,8 @@ void SimpleFinder::ReconstructDecay(const Decay& decay) {
     std::array<KFParticle, 3> track;
 
     track.at(0) = GetTrack(index_1);
-    if(std::abs(decay.GetDaughters().at(0).GetPdgHypo()) == 1000020030 ||
-       std::abs(decay.GetDaughters().at(0).GetPdgHypo()) == 1000020040) {
-      int charge = (int)track.at(0).Q();
+    if (std::abs(decay.GetDaughters().at(0).GetPdgHypo()) == 1000020030 || std::abs(decay.GetDaughters().at(0).GetPdgHypo()) == 1000020040) {
+      int charge = (int) track.at(0).Q();
       charge *= 2;
       track.at(0).Q() = charge;
       track.at(0).Px() *= std::abs(charge);
@@ -348,9 +347,8 @@ void SimpleFinder::ReconstructDecay(const Decay& decay) {
 
     for (auto index_2 : indexes.at(1)) {
       track.at(1) = GetTrack(index_2);
-      if(std::abs(decay.GetDaughters().at(1).GetPdgHypo()) == 1000020030 ||
-         std::abs(decay.GetDaughters().at(1).GetPdgHypo()) == 1000020040) {
-        int charge = (int)track.at(1).Q();
+      if (std::abs(decay.GetDaughters().at(1).GetPdgHypo()) == 1000020030 || std::abs(decay.GetDaughters().at(1).GetPdgHypo()) == 1000020040) {
+        int charge = (int) track.at(1).Q();
         charge *= 2;
         track.at(1).Q() = charge;
         track.at(1).Px() *= std::abs(charge);
@@ -382,9 +380,8 @@ void SimpleFinder::ReconstructDecay(const Decay& decay) {
         for (auto index_3 : indexes.at(2)) {
 
           track.at(2) = GetTrack(index_3);
-          if(std::abs(decay.GetDaughters().at(2).GetPdgHypo()) == 1000020030 ||
-             std::abs(decay.GetDaughters().at(2).GetPdgHypo()) == 1000020040) {
-            int charge = (int)track.at(2).Q();
+          if (std::abs(decay.GetDaughters().at(2).GetPdgHypo()) == 1000020030 || std::abs(decay.GetDaughters().at(2).GetPdgHypo()) == 1000020040) {
+            int charge = (int) track.at(2).Q();
             charge *= 2;
             track.at(2).Q() = charge;
             track.at(2).Px() *= std::abs(charge);


### PR DESCRIPTION
If reconstructed decay has non-unit charged daughters (e.g. helium), then charge and momentum must be recalculated, since by default tracking provides actually p/q instead of p and implies |q| = 1.
Shortcoming: now if-statement with He-3&4 PDGs is hardcoded. Maybe better read charge from ROOT::TDatabasePDG?