### PR TITLE
determine mc_pdg on fly from matching

### DIFF
--- a/at_interface/ConverterIn.cpp
+++ b/at_interface/ConverterIn.cpp
@@ -34,7 +34,9 @@ void ConverterIn::FillParticle(const AnalysisTree::BranchChannel& rec_particle) 
     pdg = q;
     container_.AddTrack(par, cov_matrix, mf, q, pdg, id);
   } else if (pid_mode_ == 1) {
-    pdg = rec_particle[mc_pdg_field_];
+    const int sim_id = kf2sim_tracks_->GetMatch(rec_particle.GetId());
+    if(sim_id<0) pdg = -1;
+    else         pdg = sim_tracks_[sim_id][sim_pdg_field_];
     container_.AddTrack(par, cov_matrix, mf, q, pdg, id);
   } else if (pid_mode_ == 2) {
     pdg = rec_particle[rec_pdg_field_];
@@ -92,7 +94,6 @@ void ConverterIn::Init() {
   pz_field_ = kf_tracks_.GetField("pz");
 
   q_field_ = kf_tracks_.GetField("q");
-  mc_pdg_field_ = kf_tracks_.GetField("mc_pdg");
 
   if (pid_mode_ > 1)
     rec_pdg_field_ = kf_tracks_.GetField("pid");

--- a/at_interface/ConverterIn.hpp
+++ b/at_interface/ConverterIn.hpp
@@ -114,7 +114,6 @@ class ConverterIn : public AnalysisTree::Task {
   AnalysisTree::Field pz_field_;
 
   AnalysisTree::Field q_field_;
-  AnalysisTree::Field mc_pdg_field_;
 
   AnalysisTree::Field rec_pdg_field_;
   AnalysisTree::Field prob_p_field_;


### PR DESCRIPTION
mc_pdg is an obsolete field, so MC-true PDG code of vtx track now is determined in PFSimple runtime from matching between VtxTracks and SimParticles.