### PR TITLE
Configuration of reconstruction with parameter file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,78 @@ Install PFSimple
     
 ## First run
 
-Use at_interface/main.cpp to configure the reconstruction: select cuts, number of events to analyze etc.
+The reconstruction will be executed with at_interface/main2.cpp for
+2-body decays and at_interface/main3.cpp for 3-body decays.
+
+The reconstruction can be configured with the parameter-file
+at_interface/parfile2.txt for 2-body decays and at_interface/parfile3.txt for 3-body decays.
+
+The user can select:
+1) Decay: mother and daughters
+
+   Option for daughters: alternative pdgs can be used in addition
+   for the reconstruction
+   - for background: set to "1" / "-1" for pos / neg daughters
+   - for tracks without TOF id: set to "2" / "-2" for pos / neg
+   daughters (in pid-mode 2, 3, 4)
+   - In pid-mode 0 optional daughers "1" / "-1" for pos / neg pdgs must be added.
+
+   If no alternative pdgs should be used, set to "0".
+
+   If more optional pdgs than 2 should be added, change in main2.cpp /
+   main3.cpp and recompile.
+
+2) Geometrical cuts to be applied and cut-values
+
+   If a cut should not be used, set to "-1".
+
+   For more information on specific cuts see " Constants.hpp".
+
+3) Pid-method:
+   
+   - 0: no pid (only charge information is used ! optional daughers must
+   be set to "1" / "-1" for pos / neg pdgs !)
+   
+   - 1: mc-pid
+ 
+   - 2: reconstructed TOF pid - default from Pid-framework
+   
+   - 3: reconstructed TOF pid - pdg with max. pdg-purity is selected, if pdg-purity >min. purity
+   
+   - 4: reconstructed TOF pid - pdg is selected, if pdg-purity > min. purity (pdg-specfic purities are possible)
+
+   for 2-4: Pid-framework needs to be applied first to
+   include TOF-pid & probabilities into the analysistree input-file
+
+4) Minium purities for pid-mode 3 & 4:
+   - for pid-mode 3: minimum purity is set for all pdgs (pdg-spefic purities
+   need to be set to "-1")
+   - for pid-mode 4: minimum purity can be set for all pdgs or specifically
+   for every pdg (general purity will be overwritten, if pdg-specific
+   purity is not set to "-1")
+
+5) Input/Output information:
+   - treename in input aTree, default names: "rTree" for standard aTree,
+   "aTree" after running Pid-framework
+   - branchname of reconstructed tracks in input analysistree, default names: "VtxTracks"
+     for standard analyistree, "RecParticles" after running Pid-framework
+   - number of events to be processed (-1 = all events)
+   - Output format: default output is analysistree format
+      options:
+       - plain tree: contains information about the candidates (is produced in addition to analysistree)
+	   - root tree: contains information about candidates, matched mc-particles and events (no analyistree is written)
+
+If more than one decay should be reconstructed in the same run, additional
+parfiles at_interface/parfile2_add.txt etc. can be added where 1.) & 2.) can be
+selected. 3.) - 5.) can not be changed in the same run.
+
+For 3-body decays, the list of available cuts is extended, amoung others, to cuts
+on the secondary mothers (SM) of combinations of 2 daughters. E.g. for
+H3L->p + pi + d, cuts on the SM of p-pi can be applied. The cuts
+that test the mother against the PV, e.g. chi2topo, are inverted for
+the SM to exclude SMs that come from the PV.
+
+Several example parameter files can be found in the folder at_interface.
 
 Each time before running the prepared executable you should set the environment variables to let your system know where to find libraries:
 
@@ -58,6 +129,20 @@ Each time before running the prepared executable you should set the environment 
  
 Then run the executable:
 
-    ./main2 filelist.txt
-    
-where filelist.txt must be a text file with names (including paths) to files which you want to analyze with PFSimple. Each file name should be on the next line, and the last symbol should also be a switch to next line. The example of filelist is in the source directory of PFSimple (filelist_example.txt)
+    ./main2 filelist.txt dataset parfile2.txt (parfile2_add.txt)
+
+or
+
+    ./main3 filelist.txt dataset parfile3.txt (parfile3_add.txt)
+	
+where filelist.txt must be a text file with names (including paths) to
+files which you want to analyze with PFSimple. Each file name should
+be on the next line, and the last symbol should also be a switch to
+next line. The example of filelist is in the source directory of
+PFSimple (filelist_example.txt)
+
+and where [dataset] specifies the names of the outputfiles:
+- analyistree: [dataset].PFSimpleOutput.root
+- plain tree: [dataset].PFSimplePlainTree.root
+- root tree: [dataset].PFSimpleTree.root
+

--- a/at_interface/ConverterIn.cpp
+++ b/at_interface/ConverterIn.cpp
@@ -35,7 +35,7 @@ void ConverterIn::FillParticle(const AnalysisTree::BranchChannel& rec_particle) 
     container_.AddTrack(par, cov_matrix, mf, q, pdg, id);
   } else if (pid_mode_ == 1) {
     const int sim_id = kf2sim_tracks_->GetMatch(rec_particle.GetId());
-    if(sim_id<0) pdg = -1;
+    if(sim_id<0) pdg = q;
     else         pdg = sim_tracks_[sim_id][sim_pdg_field_];
     container_.AddTrack(par, cov_matrix, mf, q, pdg, id);
   } else if (pid_mode_ == 2) {
@@ -97,7 +97,7 @@ void ConverterIn::Init() {
 
   if (pid_mode_ > 1)
     rec_pdg_field_ = kf_tracks_.GetField("pid");
-
+  
   if (pid_mode_ > 2) {
     prob_p_field_ = kf_tracks_.GetField("prob_p");
     prob_pi_field_ = kf_tracks_.GetField("prob_pi");

--- a/at_interface/main2.cpp
+++ b/at_interface/main2.cpp
@@ -2,6 +2,7 @@
 
 #include "ConverterIn.hpp"
 #include "ConverterOut.hpp"
+#include "ConverterOutTree.hpp"
 
 #include "AnalysisTree/PlainTreeFiller.hpp"
 #include "AnalysisTree/TaskManager.hpp"
@@ -9,14 +10,17 @@
 using namespace AnalysisTree;
 
 int main(int argc, char** argv) {
-  if (argc < 2) {
-    std::cout << "Wrong number of arguments! Please use:\n  ./main filelist.txt\n";
+  if (argc < 4) {
+    std::cout << "Wrong number of arguments! Please use:\n  ./main filelist.txt dataset parfile2.txt\n";
     return EXIT_FAILURE;
   }
 
-  const bool make_plain_tree{false};
+  Int_t ndecays = argc - 3;
 
-  const std::string& filename = argv[1];
+  const std::string& filename   = argv[1];
+  std::string outfilename       = std::string(argv[2]) + std::string(".PFSimpleOutput.root");
+  std::string outfilename_plain = std::string(argv[2]) + std::string(".PFSimplePlainTree.root");
+  std::string outfilename_tree  = std::string(argv[2]) + std::string(".PFSimpleTree.root");
 
   //   // ******** optimized cuts ***************
   //     Daughter proton(2212);
@@ -42,11 +46,11 @@ int main(int argc, char** argv) {
   //   Daughter pion_plus(211, {1});
   //   Daughter pion_minus(-211, {-1});
 
-  const int pid_mode = 1;// MC-PID
-  Daughter proton(2212);
-  Daughter pion(-211);
-  Daughter pion_plus(211);
-  Daughter pion_minus(-211);
+  //   const int pid_mode = 1;// MC-PID
+  //   Daughter proton(2212);
+  //   Daughter pion(-211);
+  //   Daughter pion_plus(211);
+  //   Daughter pion_minus(-211);
 
   //   const int pid_mode = 2;
   //   Daughter proton(2212, {2212, 2});// for TOF-PID
@@ -54,21 +58,22 @@ int main(int argc, char** argv) {
   //   Daughter pion_plus(211, {211, 2});
   //   Daughter pion_minus(-211, {-211, -2});
 
-  proton.SetCutChi2Prim(18.42);
-  pion_plus.SetCutChi2Prim(18.42);
+  //   proton.SetCutChi2Prim(18.42);
+  //   pion_plus.SetCutChi2Prim(18.42);
 
-  pion.SetCutChi2Prim(18.42);
-  pion_minus.SetCutChi2Prim(18.42);
+  //   pion.SetCutChi2Prim(18.42);
+  //   pion_minus.SetCutChi2Prim(18.42);
 
-  Mother lambda(3122);
-  lambda.SetCutChi2Geo(3);
-  lambda.SetCutDistance(1);
-  lambda.SetCutLdL(5);
+  //   Mother lambda(3122);
+  //   lambda.SetCutChi2Geo(3);
+  //   lambda.SetCutDistance(1);
+  //   lambda.SetCutLdL(5);
 
-  Mother kshort(310);
-  kshort.SetCutChi2Geo(3);
-  kshort.SetCutDistance(1);
-  kshort.SetCutLdL(5);
+  //   Mother kshort(310);
+  //   kshort.SetCutChi2Geo(3);
+  //   kshort.SetCutDistance(1);
+  //   kshort.SetCutLdL(5);
+
   // ***************************************
 
   //   // ******** no cuts **********************
@@ -80,21 +85,134 @@ int main(int argc, char** argv) {
   //   lambda.CancelCuts();
   //   // ***************************************
 
-  Decay lambda_pi_p("lambda", lambda, {pion, proton});
-  Decay kshort_pi_pi("kshort", kshort, {pion_minus, pion_plus});
+  const Int_t npdgs = 5;
+  const Int_t ndaughters = 2;
+
+  char name_mother [5];
+  Int_t pdg_mother;
+  std::array<Int_t, 3> pdg_1, pdg_2;
+  std::array<Float_t, ndaughters> chi2prim, cosprim;
+  Float_t dist, distSV, chi2geo, chi2topo, costopo, LdL, decaylength, distPVline;
+  Int_t pid_mode;
+  Float_t pid_purity;
+  std::array<Float_t, npdgs> purity_pdg;
+  char atree_name_c [7]; char rec_tracks_name_c [11];
+  std::string atree_name, rec_tracks_name;
+  Int_t nevents;
+  Int_t make_plain_tree, make_root_tree;
+
+  std::vector<Decay> decays;
+
+  for (int idecay = 0; idecay < ndecays; idecay++) {
+      
+    TString inputFileInfo = argv[3+idecay];
+
+    FILE *inputInfo = fopen(inputFileInfo, "r");
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_mother);
+    fscanf(inputInfo, "%s %*[^\n]%*c", name_mother);
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_1.at(0));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_1.at(1));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_1.at(2));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_2.at(0));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_2.at(1));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_2.at(2));
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%*[^\n]%*c");
+
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2prim.at(0));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2prim.at(1));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &cosprim.at(0));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &cosprim.at(1));
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%*[^\n]%*c");
+
+    fscanf(inputInfo, "%f %*[^\n]%*c", &dist);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2geo);
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%*[^\n]%*c");
+
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2topo);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &costopo);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &LdL);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &decaylength);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &distPVline);
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%*[^\n]%*c");
+
+    if (idecay == 0) {
+
+      fscanf(inputInfo, "%i %*[^\n]%*c", &pid_mode);
+      fscanf(inputInfo, "%*[^\n]%*c");
+      fscanf(inputInfo, "%*[^\n]%*c");
+
+      fscanf(inputInfo, "%f %*[^\n]%*c", &pid_purity);
+      fscanf(inputInfo, "%f %*[^\n]%*c", &purity_pdg.at(0));
+      fscanf(inputInfo, "%f %*[^\n]%*c", &purity_pdg.at(1));
+      fscanf(inputInfo, "%f %*[^\n]%*c", &purity_pdg.at(2));
+      fscanf(inputInfo, "%f %*[^\n]%*c", &purity_pdg.at(3));
+      fscanf(inputInfo, "%f %*[^\n]%*c", &purity_pdg.at(4));
+      fscanf(inputInfo, "%*[^\n]%*c");
+      fscanf(inputInfo, "%*[^\n]%*c");
+	
+      fscanf(inputInfo, "%s %*[^\n]%*c", atree_name_c);
+      fscanf(inputInfo, "%s %*[^\n]%*c", rec_tracks_name_c);
+      fscanf(inputInfo, "%i %*[^\n]%*c", &nevents);
+      fscanf(inputInfo, "%i %*[^\n]%*c", &make_plain_tree);
+      fscanf(inputInfo, "%i %*[^\n]%*c", &make_root_tree);
+      atree_name = atree_name_c;
+      rec_tracks_name = rec_tracks_name_c;
+    }
+
+    fclose(inputInfo);
+    
+    std::vector<Daughter> daughters;
+      
+    std::vector<Pdg_t> pdg_1_vec;
+    if (pdg_1.at(1) != 0 || pdg_1.at(2) != 0)	{
+      pdg_1_vec.push_back(pdg_1.at(0));
+      for (int i = 1; i < 3; i++)
+	if (pdg_1.at(i) != 0) pdg_1_vec.push_back(pdg_1.at(i));
+      Daughter daughter_1(pdg_1_vec.at(0), pdg_1_vec);
+      daughters.push_back(daughter_1);
+    }
+    else
+      daughters.push_back(pdg_1.at(0));
+      
+    std::vector<Pdg_t> pdg_2_vec;
+    if (pdg_2.at(1) != 0 || pdg_2.at(2) != 0)	{
+      pdg_2_vec.push_back(pdg_2.at(0));
+      for (int i = 1; i < 3; i++)
+	if (pdg_2.at(i) != 0) pdg_2_vec.push_back(pdg_2.at(i));
+      Daughter daughter_2(pdg_2_vec.at(0), pdg_2_vec);
+      daughters.push_back(daughter_2);
+    }
+    else
+      daughters.push_back(pdg_2.at(0));
+
+    for (size_t idaughter = 0; idaughter < daughters.size(); ++idaughter) {
+      daughters.at(idaughter).CancelCuts();
+      if (chi2prim.at(idaughter) != -1) daughters.at(idaughter).SetCutChi2Prim(chi2prim.at(idaughter));
+      if (cosprim.at(idaughter)  != -1) daughters.at(idaughter).SetCutCos(cosprim.at(idaughter));
+    }
+
+    Mother mother(pdg_mother);
+    mother.CancelCuts();
+
+    // Set cut values
+    if (dist        != -1) mother.SetCutDistance(dist);
+    if (chi2geo     != -1) mother.SetCutChi2Geo(chi2geo);
+    if (chi2topo    != -1) mother.SetCutChi2Topo(chi2topo);
+    if (costopo     != -1) mother.SetCutCosTopo(costopo);
+    if (LdL         != -1) mother.SetCutLdL(LdL);
+    if (decaylength != -1) mother.SetCutDecayLength(decaylength);
+    if (distPVline  != -1) mother.SetCutDistancePVLine(distPVline);
+
+    Decay decay(name_mother, mother, {daughters});
+    decays.push_back(decay);
+  }
 
   auto* man = TaskManager::GetInstance();
-  man->SetOutputName("PFSimpleOutput.root", "pTree");
-
-  std::string tree_name;
-  std::string rec_tracks_name;
-  if (pid_mode < 2) {
-    tree_name = "rTree";
-    rec_tracks_name = "VtxTracks";
-  } else {
-    tree_name = "aTree";
-    rec_tracks_name = "RecParticles";
-  }
 
   auto* in_converter = new ConverterIn();
   in_converter->SetRecEventHeaderName("RecEventHeader");
@@ -108,23 +226,40 @@ int main(int argc, char** argv) {
   //   in_converter->SetTrackCuts(cuts);
 
   //   in_converter->SetMotherPdgsToBeConsidered({3122});
-
+  
   in_converter->SetTrackCuts(new Cuts("Cut to reproduce KFPF", {EqualsCut((rec_tracks_name + ".pass_cuts").c_str(), 1)}));
   in_converter->SetIsShine(false);//TODO maybe change name
   in_converter->SetPidMode(pid_mode);
-  //   in_converter->SetPidPurity(min_pur);
+  if (pid_purity       != -1) in_converter->SetPidPurity(pid_purity);
+  if (purity_pdg.at(0) != -1) in_converter->SetPidPurityProton(purity_pdg.at(0)); // in pid-mode 4 pdg-specific purity possible
+  if (purity_pdg.at(1) != -1) in_converter->SetPidPurityPion(purity_pdg.at(1));
+  if (purity_pdg.at(2) != -1) in_converter->SetPidPurityKaon(purity_pdg.at(2));
+  if (purity_pdg.at(3) != -1) in_converter->SetPidPurityDeuteron(purity_pdg.at(3));
+  if (purity_pdg.at(4) != -1) in_converter->SetPidPurityBG(purity_pdg.at(4));
 
   auto* pf_task = new PFSimpleTask();
   pf_task->SetInTask(in_converter);
-  pf_task->SetDecays({lambda_pi_p, kshort_pi_pi});
+  pf_task->SetDecays({decays});
 
   auto* out_converter = new ConverterOut();
-  out_converter->SetSimEventHeaderName("SimEventHeader");
-  out_converter->SetRecTracksName(rec_tracks_name);
-  out_converter->SetSimTracksName("SimParticles");
-  out_converter->SetPFSimpleTask(pf_task);
-  out_converter->SetDecay(lambda_pi_p);
-
+  auto* out_converter_root = new ConverterOutTree();
+  if (make_root_tree) {
+    out_converter_root ->SetSimEventHeaderName("SimEventHeader");
+    out_converter_root ->SetRecTracksName(rec_tracks_name);
+    out_converter_root ->SetSimTracksName("SimParticles");
+    out_converter_root ->SetPFSimpleTask(pf_task);
+    out_converter_root ->SetDecay(decays.at(0));
+    out_converter_root ->SetOutFilename(outfilename_tree);
+  }
+  else {
+    man->SetOutputName(outfilename, "pTree");
+    out_converter->SetSimEventHeaderName("SimEventHeader");
+    out_converter->SetRecTracksName(rec_tracks_name);
+    out_converter->SetSimTracksName("SimParticles");
+    out_converter->SetPFSimpleTask(pf_task);
+    out_converter->SetDecay(decays.at(0));
+  }
+    
   //   Cuts* post_cuts = new Cuts("post_cuts", {RangeCut("Candidates.generation", 0.9, 100)});
   //   Cuts* post_cuts = new Cuts("post_cuts", {EqualsCut("Candidates.generation", 0)});
   //   Cuts* post_cuts = new Cuts("post_cuts", {RangeCut("Candidates.mass", 1.09, 1.14)});
@@ -132,18 +267,20 @@ int main(int argc, char** argv) {
 
   man->AddTask(in_converter);
   man->AddTask(pf_task);
-  man->AddTask(out_converter);
+  if (make_root_tree) man->AddTask(out_converter_root);
+  else man->AddTask(out_converter);
+ 
 
-  man->Init({filename}, {tree_name});
-  man->Run(-1);// -1 = all events
-               //   man->Run(9900);// -1 = all events
+  man->Init({filename}, {atree_name});
+  man->Run(nevents);// -1 = all events
   man->Finish();
   man->ClearTasks();
 
   if (make_plain_tree) {
     std::ofstream filelist;
     filelist.open("filelist.txt");
-    filelist << "PFSimpleOutput.root\n";
+    filelist << outfilename;
+    filelist << "\n";
     filelist.close();
 
     //    auto* tree_task_events = new PlainTreeFiller();
@@ -152,7 +289,7 @@ int main(int argc, char** argv) {
     //    tree_task_events->AddBranch(branchname_events);
 
     auto* tree_task = new PlainTreeFiller();
-    tree_task->SetOutputName("PFSimplePlainTree.root", "plain_tree");
+    tree_task->SetOutputName(outfilename_plain, "plain_tree");
     std::string branchname_rec = "Candidates";
     tree_task->SetInputBranchNames({branchname_rec});
     tree_task->AddBranch(branchname_rec);
@@ -160,7 +297,7 @@ int main(int argc, char** argv) {
     man->AddTask(tree_task);
 
     man->Init({"filelist.txt"}, {"pTree"});
-    man->Run(-1);// -1 = all events
+    man->Run(nevents);// -1 = all events
     man->Finish();
   }
 

--- a/at_interface/main3.cpp
+++ b/at_interface/main3.cpp
@@ -1,98 +1,280 @@
 #include "PFSimpleTask.hpp"
 
 #include "ConverterIn.hpp"
+#include "ConverterOut.hpp"
 #include "ConverterOutTree.hpp"
 
+#include "AnalysisTree/PlainTreeFiller.hpp"
 #include "AnalysisTree/TaskManager.hpp"
+
+using namespace AnalysisTree;
 
 int main(int argc, char** argv) {
 
-  if (argc < 2) {
-    std::cout << "Wrong number of arguments! Please use:\n  ./main filelist.txt\n";
+  if (argc < 4) {
+    std::cout << "Wrong number of arguments! Please use:\n  ./main filelist.txt dataset parfile3.txt\n";
     return EXIT_FAILURE;
   }
 
-  const std::string& filename = argv[1];
+  Int_t ndecays = argc - 3;
+  
+  const std::string& filename   = argv[1];
+  std::string outfilename       = std::string(argv[2]) + std::string(".PFSimpleOutput.root");
+  std::string outfilename_plain = std::string(argv[2]) + std::string(".PFSimplePlainTree.root");
+  std::string outfilename_tree  = std::string(argv[2]) + std::string(".PFSimpleTree.root");
 
-  //const int pid_mode = 1;// mc-pid
-  std::vector<Daughter> daughters = {2212, -211, 1000010020};
+  const Int_t npdgs = 5;
+  const Int_t ndaughters = 3;
 
-  const int pid_mode = 2;// rec-pid
-  float purity = 0.7;
-  //   std::array<float,3> purity_pdg = {0.7,0.7,0.1};
-  //   const int pid_mode = 0; // no-pid
-  //   std::vector<Daughter> daughters = {{2212, {1}}, {-211, {-1}}, {1000010020, {1}}}
+  char name_mother [5];
+  Int_t pdg_mother;
+  std::array<Int_t, 3> pdg_1, pdg_2, pdg_3;
+  std::array<Float_t, ndaughters> chi2prim, cosprim;
+  Float_t dist, distSV, chi2geo, chi2topo, costopo, LdL, decaylength, distPVline;
+  std::array<Float_t, ndaughters>  chi2geoSM, chi2topoSM, costopoSM;
+  Int_t pid_mode;
+  Float_t pid_purity;
+  std::array<Float_t, npdgs> purity_pdg;
+  char atree_name_c [7]; char rec_tracks_name_c [11];
+  std::string atree_name, rec_tracks_name;
+  Int_t nevents;
+  Int_t make_plain_tree, make_root_tree;
 
-  for (size_t idaughter = 0; idaughter < daughters.size(); ++idaughter) {
-    daughters.at(idaughter).CancelCuts();
-    daughters.at(idaughter).SetCutChi2Prim(18.42);
-    //daughters.at(idaughter).SetCutCos(0.99825);
+  std::vector<Decay> decays;
+    
+  for (int idecay = 0; idecay < ndecays; idecay++) {
+      
+    TString inputFileInfo = argv[3+idecay];
+    
+    FILE *inputInfo = fopen(inputFileInfo, "r");
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_mother);
+    fscanf(inputInfo, "%s %*[^\n]%*c", name_mother);
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_1.at(0));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_1.at(1));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_1.at(2));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_2.at(0));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_2.at(1));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_2.at(2));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_3.at(0));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_3.at(1));
+    fscanf(inputInfo, "%i %*[^\n]%*c", &pdg_3.at(2));
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%*[^\n]%*c");
+  
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2prim.at(0));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2prim.at(1));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2prim.at(2));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &cosprim.at(0));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &cosprim.at(1));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &cosprim.at(2));
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%*[^\n]%*c");
+  
+    fscanf(inputInfo, "%f %*[^\n]%*c", &dist);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &distSV);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2geoSM.at(0));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2geoSM.at(1));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2geoSM.at(2));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2geo);
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%*[^\n]%*c");
+
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2topoSM.at(0));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2topoSM.at(1));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2topoSM.at(2));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &costopoSM.at(0));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &costopoSM.at(1));
+    fscanf(inputInfo, "%f %*[^\n]%*c", &costopoSM.at(2));
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%*[^\n]%*c");
+  
+    fscanf(inputInfo, "%f %*[^\n]%*c", &chi2topo);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &costopo);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &LdL);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &decaylength);
+    fscanf(inputInfo, "%f %*[^\n]%*c", &distPVline);
+    fscanf(inputInfo, "%*[^\n]%*c");
+    fscanf(inputInfo, "%*[^\n]%*c");
+
+    if (idecay == 0) {
+
+      fscanf(inputInfo, "%i %*[^\n]%*c", &pid_mode);
+      fscanf(inputInfo, "%*[^\n]%*c");
+      fscanf(inputInfo, "%*[^\n]%*c");
+
+      fscanf(inputInfo, "%f %*[^\n]%*c", &pid_purity);
+      fscanf(inputInfo, "%f %*[^\n]%*c", &purity_pdg.at(0));
+      fscanf(inputInfo, "%f %*[^\n]%*c", &purity_pdg.at(1));
+      fscanf(inputInfo, "%f %*[^\n]%*c", &purity_pdg.at(2));
+      fscanf(inputInfo, "%f %*[^\n]%*c", &purity_pdg.at(3));
+      fscanf(inputInfo, "%f %*[^\n]%*c", &purity_pdg.at(4));
+      fscanf(inputInfo, "%*[^\n]%*c");
+      fscanf(inputInfo, "%*[^\n]%*c");
+
+      fscanf(inputInfo, "%s %*[^\n]%*c", atree_name_c);
+      fscanf(inputInfo, "%s %*[^\n]%*c", rec_tracks_name_c);
+      fscanf(inputInfo, "%i %*[^\n]%*c", &nevents);
+      fscanf(inputInfo, "%i %*[^\n]%*c", &make_plain_tree);
+      fscanf(inputInfo, "%i %*[^\n]%*c", &make_root_tree);
+	
+      atree_name = atree_name_c;
+      rec_tracks_name = rec_tracks_name_c;
+    }
+
+    fclose(inputInfo);
+ 
+    std::vector<Daughter> daughters;
+      
+    std::vector<Pdg_t> pdg_1_vec;
+    if (pdg_1.at(1) != 0 || pdg_1.at(2) != 0)	{
+      pdg_1_vec.push_back(pdg_1.at(0));
+      for (int i = 1; i < 3; i++)
+	if (pdg_1.at(i) != 0) pdg_1_vec.push_back(pdg_1.at(i));
+      Daughter daughter_1(pdg_1_vec.at(0), pdg_1_vec);
+      daughters.push_back(daughter_1);
+    }
+    else
+      daughters.push_back(pdg_1.at(0));
+      
+    std::vector<Pdg_t> pdg_2_vec;
+    if (pdg_2.at(1) != 0 || pdg_2.at(2) != 0)	{
+      pdg_2_vec.push_back(pdg_2.at(0));
+      for (int i = 1; i < 3; i++)
+	if (pdg_2.at(i) != 0) pdg_2_vec.push_back(pdg_2.at(i));
+      Daughter daughter_2(pdg_2_vec.at(0), pdg_2_vec);
+      daughters.push_back(daughter_2);
+    }
+    else
+      daughters.push_back(pdg_2.at(0));
+
+    std::vector<Pdg_t> pdg_3_vec;
+    if (pdg_3.at(1) != 0 || pdg_3.at(2) != 0)	{
+      pdg_3_vec.push_back(pdg_3.at(0));
+      for (int i = 1; i < 3; i++)
+	if (pdg_3.at(i) != 0) pdg_3_vec.push_back(pdg_3.at(i));
+      Daughter daughter_3(pdg_3_vec.at(0), pdg_3_vec);
+      daughters.push_back(daughter_3);
+    }
+    else
+      daughters.push_back(pdg_3.at(0));
+
+
+    for (size_t idaughter = 0; idaughter < daughters.size(); ++idaughter) {
+      daughters.at(idaughter).CancelCuts();
+      if (chi2prim.at(idaughter) != -1) daughters.at(idaughter).SetCutChi2Prim(chi2prim.at(idaughter));
+      if (cosprim.at(idaughter)  != -1) daughters.at(idaughter).SetCutCos(cosprim.at(idaughter));
+    }
+    Mother mother(pdg_mother);
+    mother.CancelCuts();
+
+    // Set cut values
+    if (dist        != -1) mother.SetCutDistance(dist);
+    if (distSV      != -1) mother.SetCutDistanceToSV(distSV);
+    if (chi2geo     != -1) mother.SetCutChi2Geo(chi2geo);
+    if (chi2topo    != -1) mother.SetCutChi2Topo(chi2topo);
+    if (costopo     != -1) mother.SetCutCosTopo(costopo);
+    if (LdL         != -1) mother.SetCutLdL(LdL);
+    if (decaylength != -1) mother.SetCutDecayLength(decaylength);
+    if (distPVline  != -1) mother.SetCutDistancePVLine(distPVline);
+
+    std::vector<Float_t> chi2geoSM_vec;
+    for (int i = 0; i < ndaughters; i++)
+      if (chi2geoSM.at(i) != -1)
+	chi2geoSM_vec.push_back(chi2geoSM.at(i));
+      else break;
+    if (chi2geoSM_vec.size() > 0)
+      mother.SetCutChi2GeoSM({chi2geoSM_vec});
+
+    std::vector<Float_t> chi2topoSM_vec;
+    for (int i = 0; i < ndaughters; i++)
+      if (chi2topoSM.at(i) != -1)
+	chi2topoSM_vec.push_back(chi2topoSM.at(i));
+      else break;
+    if (chi2topoSM_vec.size() > 0)
+      mother.SetCutChi2TopoSM({chi2topoSM_vec});
+
+    std::vector<Float_t> costopoSM_vec;
+    for (int i = 0; i < ndaughters; i++)
+      if (costopoSM.at(i) != -1)
+	costopoSM_vec.push_back(costopoSM.at(i));
+      else break;
+    if (costopoSM_vec.size() > 0)
+      mother.SetCutCosTopoSM({costopoSM_vec});
+
+    Decay decay(name_mother, mother, {daughters});
+    decays.push_back(decay);
   }
-  Mother mother(3004);
-  mother.CancelCuts();
-  mother.SetCutDistance(1.0);
-  mother.SetCutChi2GeoSM({3.0});
-  //mother.SetCutChi2TopoSM({29});
-  mother.SetCutDistanceToSV(1.0);
-  //mother.SetCutChi2Geo(3.0);
-  //mother.SetCutChi2Topo(29);
-  //mother.SetCutLdL(3);
-  Decay decay("H3L", mother, {daughters});
 
-  std::string outname;
-  if (argc > 2) outname = argv[2];
-  else
-    outname = "PFSimpleOutput";
-  std::string outfilename;
-  if (pid_mode == 1) outfilename = outname + "_pid_mc.root";
-  if (pid_mode > 1) outfilename = outname + "_pid_rec.root";
-
-  std::string tracks_name;
-  if (pid_mode < 2) tracks_name = "VtxTracks";
-  else
-    tracks_name = "RecTracks";
-
-  auto* man = AnalysisTree::TaskManager::GetInstance();
-  //man->SetOutputName("PFSimpleOutput.root", "pTree");
+  auto* man = TaskManager::GetInstance();
 
   auto* in_converter = new ConverterIn();
   in_converter->SetRecEventHeaderName("RecEventHeader");
-  in_converter->SetRecTracksName(tracks_name);
+  in_converter->SetRecTracksName(rec_tracks_name);
   in_converter->SetSimTracksName("SimParticles");
-  in_converter->SetTrackCuts(new AnalysisTree::Cuts("Cut to reproduce KFPF", {AnalysisTree::EqualsCut(tracks_name + ".pass_cuts", 1)}));
+  in_converter->SetTrackCuts(new Cuts("Cut to reproduce KFPF", {EqualsCut((rec_tracks_name + ".pass_cuts").c_str(), 1)}));
   in_converter->SetIsShine(false);//TODO maybe change name
-  in_converter->SetPidMode(pid_mode);
-  if (pid_mode > 2) {
-    in_converter->SetPidPurity(purity);
-    //in_converter->SetPidPurityProton(purity_pdg.at(0)); // in pid-mode 3 pdg-specific purity possible
-    //in_converter->SetPidPurityPion(purity_pdg.at(1));
-    //in_converter->SetPidPurityDeuteron(purity_pdg.at(2));
-  }
 
+  in_converter->SetPidMode(pid_mode);
+  if (pid_purity       != -1) in_converter->SetPidPurity(pid_purity);
+  if (purity_pdg.at(0) != -1) in_converter->SetPidPurityProton(purity_pdg.at(0)); // in pid-mode 4 pdg-specific purity possible
+  if (purity_pdg.at(1) != -1) in_converter->SetPidPurityPion(purity_pdg.at(1));
+  if (purity_pdg.at(2) != -1) in_converter->SetPidPurityKaon(purity_pdg.at(2));
+  if (purity_pdg.at(3) != -1) in_converter->SetPidPurityDeuteron(purity_pdg.at(3));
+  if (purity_pdg.at(4) != -1) in_converter->SetPidPurityBG(purity_pdg.at(4));
+ 
   auto* pf_task = new PFSimpleTask();
   pf_task->SetInTask(in_converter);
-  pf_task->SetDecays({decay});
+  pf_task->SetDecays({decays});
 
-  auto* out_converter = new ConverterOutTree();
-  out_converter->SetSimEventHeaderName("SimEventHeader");
-  out_converter->SetRecTracksName("RecParticles");
-  out_converter->SetSimTracksName("SimParticles");
-  out_converter->SetPFSimpleTask(pf_task);
-  out_converter->SetDecay(decay);
-  //   out_converter->SetPidMode(pid_mode);
-  out_converter->SetOutFilename(outfilename);
-
+  auto* out_converter = new ConverterOut();
+  auto* out_converter_root = new ConverterOutTree();
+  if (make_root_tree) {
+    out_converter_root ->SetSimEventHeaderName("SimEventHeader");
+    out_converter_root ->SetRecTracksName(rec_tracks_name);
+    out_converter_root ->SetSimTracksName("SimParticles");
+    out_converter_root ->SetPFSimpleTask(pf_task);
+    out_converter_root ->SetDecay(decays.at(0));
+    out_converter_root ->SetOutFilename(outfilename_tree);
+    }
+  else {
+    man->SetOutputName(outfilename, "pTree");
+    out_converter->SetSimEventHeaderName("SimEventHeader");
+    out_converter->SetRecTracksName(rec_tracks_name);
+    out_converter->SetSimTracksName("SimParticles");
+    out_converter->SetPFSimpleTask(pf_task);
+    out_converter->SetDecay(decays.at(0));
+  }
+  
   man->AddTask(in_converter);
   man->AddTask(pf_task);
-  man->AddTask(out_converter);
-
-  if (pid_mode < 2)
-    man->Init({filename}, {"rTree"});
-  else
-    man->Init({filename}, {"pTree"});
-  man->Run(-1);// -1 = all events
+  if (make_root_tree) man->AddTask(out_converter_root);
+  else man->AddTask(out_converter);
+ 
+  man->Init({filename}, {atree_name});
+  man->Run(nevents);// -1 = all events
   man->Finish();
   man->ClearTasks();
+
+  if (make_plain_tree) {
+    std::ofstream filelist;
+    filelist.open("filelist.txt");
+    filelist << outfilename;
+    filelist << "\n";
+    filelist.close();
+
+    auto* tree_task = new PlainTreeFiller();
+    tree_task->SetOutputName(outfilename_plain, "plain_tree");
+    std::string branchname_rec = "Candidates";
+    tree_task->SetInputBranchNames({branchname_rec});
+    tree_task->AddBranch(branchname_rec);
+
+    man->AddTask(tree_task);
+
+    man->Init({"filelist.txt"}, {"pTree"});
+    man->Run(nevents);// -1 = all events
+    man->Finish();
+  }
 
   return EXIT_SUCCESS;
 }

--- a/at_interface/parfile2.txt
+++ b/at_interface/parfile2.txt
@@ -1,0 +1,44 @@
+## Decay
+3122,                 pdg mother
+Lambda              pdg name
+-211,                 pdg daughter 1
+0,                       optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+2212,                 pdg daughter 2
+0,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+--------------------------------------------------------------------------
+## Geometrical cuts for daughters
+18.42,               cut chi2 to PV 1
+18.42,               cut chi2 to PV 2
+-1,                    cut cos to PV 1
+-1,                    cut cos to PV 2
+--------------------------------------------------------------------------
+## Geometrical cuts for combinations of daughters
+1.0,                   cut distance daughter 1 & 2
+3.0,                   cut chi2geo
+--------------------------------------------------------------------------
+## Geometrical cuts for mother
+-1,                    cut chi2topo
+-1,                    cut costopo
+5.0,                   cut LdL
+-1,                    cut decaylength L
+-1,                    cut distance to PV line
+--------------------------------------------------------------------------
+## Pid method
+1,                       pid mode: =0: no pid; =1: mc pid; =2: rec pid (default); =3: rec pid (max. purity & purity > min. purity); =4 (purity > min. purity)
+--------------------------------------------------------------------------
+## Minimum required purities for TOF pid for pid mode = 3 & 4
+-1,                    purity tof for all daughter species (will be overwritten by specific purity, if specific purity != -1) 
+-1,                    specific purity tof for protons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for pions (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for kaons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for deuterons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for background (optional, if = -1: purity for all species will be used)
+--------------------------------------------------------------------------
+## Input / Output information
+rTree                  treename in input analysistree
+VtxTracks          branchname for reconstructed tracks in input analysistree
+-1,                     number of events to be processed (-1 = all events)
+1,                       make plain tree: =1; make no plain tree: =0
+0,                       make root-tree: =1 (no analysistree is written); make no root-tree: =0

--- a/at_interface/parfile2_add.txt
+++ b/at_interface/parfile2_add.txt
@@ -1,0 +1,26 @@
+## Decay
+310,                 pdg mother
+Kshort              pdg name
+-211,                 pdg daughter 1
+0,                       optional: additional pdg to be considered for daughter 1  (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 1  (=0: no additional pdg)
+211,                 pdg daughter 2
+0,                       optional: additional pdg to be considered for daughter 2  (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 2  (=0: no additional pdg)
+--------------------------------------------------------------------------
+## Geometrical cuts for daughters
+18.42,               cut chi2 to PV 1
+18.42,               cut chi2 to PV 2
+-1,                    cut cos to PV 1
+-1,                    cut cos to PV 2
+--------------------------------------------------------------------------
+## Geometrical cuts for combinations of daughters
+1.0,                   cut distance daughter 1 & 2
+3.0,                   cut chi2geo
+--------------------------------------------------------------------------
+## Geometrical cuts for mother
+-1,                    cut chi2topo
+-1,                    cut costopo
+5.0,                   cut LdL
+-1,                    cut decaylength L
+-1,                    cut distance to PV line

--- a/at_interface/parfile2_lambda_pidmode0.txt
+++ b/at_interface/parfile2_lambda_pidmode0.txt
@@ -1,0 +1,44 @@
+## Decay
+3122,                 pdg mother
+Lambda              pdg name
+-211,                 pdg daughter 1
+-1,                     optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+2212,                 pdg daughter 2
+1,                       optional: additional pdg to be considered for daughter 2  (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+--------------------------------------------------------------------------
+## Geometrical cuts for daughters
+18.42,               cut chi2 to PV 1
+18.42,               cut chi2 to PV 2
+-1,                    cut cos to PV 1
+-1,                    cut cos to PV 2
+--------------------------------------------------------------------------
+## Geometrical cuts for combinations of daughters
+1.0,                   cut distance daughter 1 & 2
+3.0,                   cut chi2geo
+--------------------------------------------------------------------------
+## Geometrical cuts for mother
+-1,                    cut chi2topo
+-1,                    cut costopo
+5.0,                   cut LdL
+-1,                    cut decaylength L
+-1,                    cut distance to PV line
+--------------------------------------------------------------------------
+## Pid method
+0,                       pid mode: =0: no pid; =1: mc pid; =2: rec pid (default); =3: rec pid (max. purity & purity > min. purity); =4 (purity > min. purity)
+--------------------------------------------------------------------------
+## Minimum required purities for TOF pid for pid mode = 3 & 4
+-1,                    purity tof for all daughter species (will be overwritten by specific purity, if specific purity != -1) 
+-1,                    specific purity tof for protons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for pions (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for kaons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for deuterons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for background (optional, if = -1: purity for all species will be used)
+--------------------------------------------------------------------------
+## Input / Output information
+rTree                  treename in input analysistree
+VtxTracks          branchname for reconstructed tracks in input analysistree
+-1,                     number of events to be processed (-1 = all events)
+1,                       make plain tree: =1; make no plain tree: =0
+0,                       make root-tree: =1 (no analysistree is written); make no root-tree: =0

--- a/at_interface/parfile2_lambda_pidmode1_optcut.txt
+++ b/at_interface/parfile2_lambda_pidmode1_optcut.txt
@@ -1,0 +1,44 @@
+## Decay
+3122,                 pdg mother
+Lambda              pdg name
+-211,                 pdg daughter 1
+0,                       optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+2212,                 pdg daughter 2
+0,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+--------------------------------------------------------------------------
+## Geometrical cuts for daughters
+110.00,             cut chi2 to PV 1
+26.00,               cut chi2 to PV 2
+-1,                    cut cos to PV 1
+0.99825,           cut cos to PV 2
+--------------------------------------------------------------------------
+## Geometrical cuts for combinations of daughters
+0.15,                 cut distance daughter 1 & 2
+11.0,                 cut chi2geo
+--------------------------------------------------------------------------
+## Geometrical cuts for mother
+29.0,                 cut chi2topo
+-1,                    cut costopo
+4.0,                   cut LdL
+-1,                    cut decaylength L
+-1,                    cut distance to PV line
+--------------------------------------------------------------------------
+## Pid method
+1,                       pid mode: =0: no pid; =1: mc pid; =2: rec pid (default); =3: rec pid (max. purity & purity > min. purity); =4 (purity > min. purity)
+--------------------------------------------------------------------------
+## Minimum required purities for TOF pid for pid mode = 3 & 4
+-1,                    purity tof for all daughter species (will be overwritten by specific purity, if specific purity != -1) 
+-1,                    specific purity tof for protons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for pions (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for kaons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for deuterons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for background (optional, if = -1: purity for all species will be used)
+--------------------------------------------------------------------------
+## Input / Output information
+rTree                  treename in input analysistree
+VtxTracks          branchname for reconstructed tracks in input analysistree
+-1,                     number of events to be processed (-1 = all events)
+1,                       make plain tree: =1; make no plain tree: =0
+0,                       make root-tree: =1 (no analysistree is written); make no root-tree: =0

--- a/at_interface/parfile2_lambda_pidmode2.txt
+++ b/at_interface/parfile2_lambda_pidmode2.txt
@@ -1,0 +1,44 @@
+## Decay
+3122,                 pdg mother
+Lambda              pdg name
+-211,                 pdg daughter 1
+-2,                     optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+2212,                 pdg daughter 2
+2,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+--------------------------------------------------------------------------
+## Geometrical cuts for daughters
+18.42,             cut chi2 to PV 1
+18.42,             cut chi2 to PV 2
+-1,                  cut cos to PV 1
+-1,                  cut cos to PV 2
+--------------------------------------------------------------------------
+## Geometrical cuts for combinations of daughters
+1.0,                   cut distance daughter 1 & 2
+3.0,                   cut chi2geo
+--------------------------------------------------------------------------
+## Geometrical cuts for mother
+-1,                    cut chi2topo
+-1,                    cut costopo
+5.0,                   cut LdL
+-1,                    cut decaylength L
+-1,                    cut distance to PV line
+--------------------------------------------------------------------------
+## Pid method
+2,                       pid mode: =0: no pid; =1: mc pid; =2: rec pid (default); =3: rec pid (max. purity & purity > min. purity); =4 (purity > min. purity)
+--------------------------------------------------------------------------
+## Minimum required purities for TOF pid for pid mode = 3 & 4
+-1,                    purity tof for all daughter species (will be overwritten by specific purity, if specific purity != -1) 
+-1,                    specific purity tof for protons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for pions (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for kaons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for deuterons (optional, if = -1: purity for all species will be used)
+-1,                    specific purity tof for background (optional, if = -1: purity for all species will be used)
+--------------------------------------------------------------------------
+## Input / Output information
+aTree                  treename in input analysistree
+RecParticles       branchname for reconstructed tracks in analyistree
+-1,                     number of events to be processed (-1 = all events)
+1,                       make plain tree: =1; make no plain tree: =0
+0,                       make root-tree: =1 (no analysistree is written); make no root-tree: =0

--- a/at_interface/parfile3.txt
+++ b/at_interface/parfile3.txt
@@ -1,0 +1,61 @@
+## Decay
+3004,                 pdg mother
+H3L                    pdg name
+2212,                 pdg daughter 1
+0,		      	  optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+-211,                 pdg daughter 2
+0,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+1000010020,     pdg daughter 3
+0,                       optional: additional pdg to be considered for daughter 3 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 3 (=0: no additional pdg)
+--------------------------------------------------------------------------
+## Geometrical cuts for daughters
+18.42,                cut chi2 to PV 1
+18.42,                cut chi2 to PV 2
+10.0,                  cut chi2 to PV 3
+-1,                     cut cos to PV 1
+-1,                     cut cos to PV 2
+-1,                     cut cos to PV 3
+--------------------------------------------------------------------------
+## Geometrical cuts for combinations of daughters
+0.2,                    cut distance daughter 1 & 2
+0.2,                    cut distance SV (distance between daughter 3 and SV)
+3.0,                    cut chi2geo SM 1 (dauther 1 & 2)
+-1,                     cut chi2geo SM 2 (dauther 1 & 3)
+-1,                     cut chi2geo SM 3 (dauther 2 & 3)
+-1,                     cut chi2geo (daughter 1, 2 & 3)
+--------------------------------------------------------------------------
+## Geometrical cuts for secondary mothers (of daugher 1&2, 1&3, 2&3)
+2.0,                    cut chi2topo SM 1 (dauther 1 & 2)
+-1,                     cut chi2topo SM 2 (dauther 1 & 3)
+-1,                     cut chi2topo SM 3 (dauther 2 & 3)
+-1,                     cut costopo SM 1 (dauther 1 & 2)
+-1,                     cut costopo SM 2 (dauther 1 & 3)
+-1,                     cut costopo SM 3 (dauther 2 & 3)
+--------------------------------------------------------------------------
+## Geometrical cuts for mother
+-1,                     cut chi2topo
+-1,                     cut costopo
+10.0,                  cut LdL
+-1,                     cut decaylength L
+-1,                     cut distance to PV line
+--------------------------------------------------------------------------
+## Pid method
+4,                       pid mode: =0: no pid; =1: mc pid; =2: rec pid (default); =3: rec pid (max. purity & purity > min. purity); =4 (purity > min. purity)
+--------------------------------------------------------------------------
+## Minimum required purities for TOF pid for pid mode = 3 & 4
+0.5,                    purity tof for all daughter species (will be overwritten by specific purity, if specific purity != -1) 
+0.7,                    specific purity tof for protons (optional, if = -1: purity for all species will be used)
+0.7,                    specific purity tof for pions (optional, if = -1: purity for all species will be used)
+0.7,                    specific purity tof for kaons (optional, if = -1: purity for all species will be used)
+0.2,                    specific purity tof for deuterons (optional, if = -1: purity for all species will be used)
+0.7,                    specific purity tof for background (optional, if = -1: purity for all species will be used)
+--------------------------------------------------------------------------
+## Input / Output information
+pTree                  treename in input analysistree
+RecTracks          branchname for reconstructed tracks in input analysistree
+-1,                     number of events to be processed (-1 = all events)
+0,                       make plain tree: =1; make no plain tree: =0
+1,                       make root-tree: =1 (no analysistree is written); make no root-tree: =0

--- a/at_interface/parfile3_add.txt
+++ b/at_interface/parfile3_add.txt
@@ -1,0 +1,43 @@
+## Decay
+3007,                 pdg mother
+He5L                  pdg name
+2212,                 pdg daughter 1
+0,		      	  optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 1 (=0: no additional pdg)
+-211,                 pdg daughter 2
+0,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 2 (=0: no additional pdg)
+1000020040,     pdg daughter 3
+0,                       optional: additional pdg to be considered for daughter 3 (=0: no additional pdg)
+0,                       optional: additional pdg to be considered for daughter 3 (=0: no additional pdg)
+--------------------------------------------------------------------------
+## Geometrical cuts for daughters
+18.42,                cut chi2 to PV 1
+18.42,                cut chi2 to PV 2
+10.0,                  cut chi2 to PV 3
+-1,                     cut cos to PV 1
+-1,                     cut cos to PV 2
+-1,                     cut cos to PV 3
+--------------------------------------------------------------------------
+## Geometrical cuts for combinations of daughters
+0.2,                    cut distance daughter 1 & 2
+0.2,                    cut distance SV (distance between daughter 3 and SV)
+3.0,                    cut chi2geo SM 1 (dauther 1 & 2)
+-1,                     cut chi2geo SM 2 (dauther 1 & 3)
+-1,                     cut chi2geo SM 3 (dauther 2 & 3)
+-1,                     cut chi2geo (daughter 1, 2 & 3)
+--------------------------------------------------------------------------
+## Geometrical cuts for secondary mothers (of daugher 1&2, 1&3, 2&3)
+2.0,                    cut chi2topo SM 1 (dauther 1 & 2)
+-1,                     cut chi2topo SM 2 (dauther 1 & 3)
+-1,                     cut chi2topo SM 3 (dauther 2 & 3)
+-1,                     cut costopo SM 1 (dauther 1 & 2)
+-1,                     cut costopo SM 2 (dauther 1 & 3)
+-1,                     cut costopo SM 3 (dauther 2 & 3)
+--------------------------------------------------------------------------
+## Geometrical cuts for mother
+-1,                     cut chi2topo
+-1,                     cut costopo
+10.0,                  cut LdL
+-1,                     cut decaylength L
+-1,                     cut distance to PV line

--- a/src/Constants.hpp
+++ b/src/Constants.hpp
@@ -14,7 +14,7 @@ struct SelectionValues {
   float distance{-1.f};                                    ///< Distance between daughter tracks in their closest approach
   float distance_sv{-1.f};                                 ///< Distance between daughter track and SV
   float l{-1.f};                                           ///< Lenght of interpolated track from secondary to primary vertex
-  float l_over_dl{-1.f};                                   ///< Distance between primary and secondary vertices divided by error
+  float l_over_dl{-1.f};                                   ///< Lenght of interpolated track from secondary to primary vertex divided by error
   float distance_pv{-1.f};                                 ///< Distance between secondary vertex and primary vertex line
   std::array<float, 4> chi2_geo{{-1.f, -1.f, -1.f, -1.f}}; ///< \f$\chi^2\f$ of daughters' tracks in their closest approach (prim & sec mothers)
   std::array<float, 4> chi2_topo{{-1.f, -1.f, -1.f, -1.f}};///< \f$\chi^2\f$ of the mother's track to the PV (prim & sec mothers)

--- a/src/Daughter.hpp
+++ b/src/Daughter.hpp
@@ -34,12 +34,12 @@ class Daughter {
   void CancelCuts();
 
  protected:
-  Pdg_t pdg_hypo_{-1};         ///< PDG code hypothesis
-  std::vector<Pdg_t> pids_{};  ///< vector of PDG codes to use
-  float chi2_prim_{18.4207};   ///< \f$\chi^2\f$ lower value
-  //float cos_{0.f};             ///< cosine lower value
-  float cos_{  -huge_value};  ///< cosine lower value   
-  int id_{-1};                 ///< daughther number (0, 1, 2)
+  Pdg_t pdg_hypo_{-1};       ///< PDG code hypothesis
+  std::vector<Pdg_t> pids_{};///< vector of PDG codes to use
+  float chi2_prim_{18.4207}; ///< \f$\chi^2\f$ lower value
+  //float cos_{0.f};           ///< cosine lower value
+  float cos_{  -huge_value}; ///< cosine lower value   
+  int id_{-1};               ///< daughther number (0, 1, 2)
 };
 
 #endif//KFPARTICLESIMPLE_KFSIMPLE_DAUGHTERCUTS_HPP_

--- a/src/Daughter.hpp
+++ b/src/Daughter.hpp
@@ -37,7 +37,6 @@ class Daughter {
   Pdg_t pdg_hypo_{-1};       ///< PDG code hypothesis
   std::vector<Pdg_t> pids_{};///< vector of PDG codes to use
   float chi2_prim_{18.4207}; ///< \f$\chi^2\f$ lower value
-  //float cos_{0.f};           ///< cosine lower value
   float cos_{-huge_value};   ///< cosine lower value   
   int id_{-1};               ///< daughther number (0, 1, 2)
 };

--- a/src/Daughter.hpp
+++ b/src/Daughter.hpp
@@ -34,11 +34,12 @@ class Daughter {
   void CancelCuts();
 
  protected:
-  Pdg_t pdg_hypo_{-1};       ///< PDG code hypothesis
-  std::vector<Pdg_t> pids_{};///< vector of PDG codes to use
-  float chi2_prim_{18.4207}; ///< \f$\chi^2\f$ lower value
-  float cos_{0.f};           ///< cosine lower value
-  int id_{-1};               ///< daughther number (0, 1, 2)
+  Pdg_t pdg_hypo_{-1};         ///< PDG code hypothesis
+  std::vector<Pdg_t> pids_{};  ///< vector of PDG codes to use
+  float chi2_prim_{18.4207};   ///< \f$\chi^2\f$ lower value
+  //float cos_{0.f};             ///< cosine lower value
+  float cos_{  -huge_value};  ///< cosine lower value   
+  int id_{-1};                 ///< daughther number (0, 1, 2)
 };
 
 #endif//KFPARTICLESIMPLE_KFSIMPLE_DAUGHTERCUTS_HPP_

--- a/src/Daughter.hpp
+++ b/src/Daughter.hpp
@@ -37,7 +37,7 @@ class Daughter {
   Pdg_t pdg_hypo_{-1};       ///< PDG code hypothesis
   std::vector<Pdg_t> pids_{};///< vector of PDG codes to use
   float chi2_prim_{18.4207}; ///< \f$\chi^2\f$ lower value
-  float cos_{-huge_value};   ///< cosine lower value   
+  float cos_{-huge_value};   ///< cosine lower value
   int id_{-1};               ///< daughther number (0, 1, 2)
 };
 

--- a/src/Daughter.hpp
+++ b/src/Daughter.hpp
@@ -38,7 +38,7 @@ class Daughter {
   std::vector<Pdg_t> pids_{};///< vector of PDG codes to use
   float chi2_prim_{18.4207}; ///< \f$\chi^2\f$ lower value
   //float cos_{0.f};           ///< cosine lower value
-  float cos_{  -huge_value}; ///< cosine lower value   
+  float cos_{-huge_value};   ///< cosine lower value   
   int id_{-1};               ///< daughther number (0, 1, 2)
 };
 


### PR DESCRIPTION
Configuration of decays, cuts, etc. with parameter-file (no compiling is needed for user changes). Example parfiles are in at_interface (see also updated Readme.md).
Small additional changes:
- Consider charge for background in pid-mode 1. 
- Small correction of definition of cut L/dL.
- Synchronization of default value for cut cos with cancel cuts.