### PR TITLE
Make RecEventHeader branch name configurable

### DIFF
--- a/at_interface/main_json.cpp
+++ b/at_interface/main_json.cpp
@@ -93,7 +93,7 @@ int main(int argc, char** argv) {
     auto* man = TaskManager::GetInstance();
 
     auto* in_converter = new ConverterIn();
-    in_converter->SetRecEventHeaderName("RecEventHeader");
+    in_converter->SetRecEventHeaderName(config["io"].value("receventheader_branchname", "RecEventHeader"));
     in_converter->SetRecTracksName(config["io"]["rectracks_branchname"]);
     in_converter->SetSimTracksName("SimParticles");
     in_converter->SetTrackCuts(new Cuts("Cut to reproduce KFPF", {EqualsCut((config["io"]["rectracks_branchname"].get<std::string>() + ".pass_cuts").c_str(), 1)}));


### PR DESCRIPTION
This update ads the possible field receventheader_branchname in the configs io block. If it is not present, the default name "RecEventHeader" is used. It was neccessary because in some newer productions when the centrality framework is applied the branchname changes to AnaEventHeader.